### PR TITLE
Add Suspend and Delete Scans Endpoint DNSTool-Middleware-API[API-Gateway]

### DIFF
--- a/api-gateway/config/__init__.py
+++ b/api-gateway/config/__init__.py
@@ -10,6 +10,7 @@ class Config:
     PRESERVE_CONTEXT_ON_EXCEPTION: bool = True
     FIREBASE_JSON: str = os.environ.get("FIREBASE_JSON")
     FIREBASE_DATABASE_URL: str = os.environ.get("FIREBASE_DATABASE_URL")
+    FIREBASE_API_KEY: str = os.environ.get("FIREBASE_API_KEY")
     GCS_JSON: str = os.environ.get("GCS_JSON")
     GCS_BUCKET_NAME: str = os.environ.get("GCS_BUCKET_NAME")
     MAIL_SERVER: str = os.environ.get("MAIL_SERVER")

--- a/api-gateway/controllers/controllers.py
+++ b/api-gateway/controllers/controllers.py
@@ -44,10 +44,27 @@ class GCPZonesController(Resource):
         return service.get_gcp_zone(query)
 
 
-class CreateScanController(Resource):
+class ScansController(Resource):
     method_decorators: Dict[str, List[Callable]] = dict(post=[validator])
     model: str = "CreateScan"
 
     @authenticate
     def post(self, request_body: Dict[str, Any], uid: str) -> ResourceType:
         return service.create_scan(request_body, uid)
+
+    @authenticate
+    def get(self, uid: str) -> ResourceType:
+        return service.get_scans(uid)
+
+
+class ScanController(Resource):
+    method_decorators: Dict[str, List[Callable]] = dict(patch=[validator])
+    model: str = "UpdateScan"
+
+    @authenticate
+    def patch(self, id: str, request_body: Dict[str, Any], uid: str) -> ResourceType:
+        return service.update_scan(id, request_body, uid)
+
+    @authenticate
+    def delete(self, id: str, uid: str) -> ResourceType:
+        return service.delete_scan(id, uid)

--- a/api-gateway/controllers/controllers.py
+++ b/api-gateway/controllers/controllers.py
@@ -45,12 +45,11 @@ class GCPZonesController(Resource):
 
 
 class ScansController(Resource):
-    method_decorators: Dict[str, List[Callable]] = dict(post=[validator])
+    method_decorators: Dict[str, List[Callable]] = dict(post=[validator, authenticate])
     model: str = "CreateScan"
 
-    @authenticate
-    def post(self, request_body: Dict[str, Any], uid: str) -> ResourceType:
-        return service.create_scan(request_body, uid)
+    def post(self, uid: str, request_body: Dict[str, Any]) -> ResourceType:
+        return service.create_scan(uid, request_body)
 
     @authenticate
     def get(self, uid: str) -> ResourceType:
@@ -58,13 +57,14 @@ class ScansController(Resource):
 
 
 class ScanController(Resource):
-    method_decorators: Dict[str, List[Callable]] = dict(patch=[validator])
+    method_decorators: Dict[str, List[Callable]] = dict(patch=[validator, authenticate])
     model: str = "UpdateScan"
 
-    @authenticate
-    def patch(self, id: str, request_body: Dict[str, Any], uid: str) -> ResourceType:
-        return service.update_scan(id, request_body, uid)
+    def patch(
+        self, uid: str, request_body: Dict[str, Any], **kwargs: Dict[str, str]
+    ) -> ResourceType:
+        return service.update_scan(uid, request_body, **kwargs)
 
     @authenticate
-    def delete(self, id: str, uid: str) -> ResourceType:
-        return service.delete_scan(id, uid)
+    def delete(self, uid: str, **kwargs: Dict[str, str]) -> ResourceType:
+        return service.delete_scan(uid, **kwargs)

--- a/api-gateway/controllers/routes.py
+++ b/api-gateway/controllers/routes.py
@@ -4,7 +4,8 @@ from .controllers import (
     RegistrationController,
     EmailDomainCheckController,
     GCPZonesController,
-    CreateScanController,
+    ScansController,
+    ScanController,
 )
 from flask_restful import Api
 
@@ -15,4 +16,5 @@ def initialize_routes(api: Api) -> None:
     api.add_resource(RegistrationController, "/register")
     api.add_resource(EmailDomainCheckController, "/check-email")
     api.add_resource(GCPZonesController, "/gcp-zones/<query>")
-    api.add_resource(CreateScanController, "/scan")
+    api.add_resource(ScansController, "/scans")
+    api.add_resource(ScanController, "/scans/<id>")

--- a/api-gateway/database/__init__.py
+++ b/api-gateway/database/__init__.py
@@ -46,7 +46,7 @@ class FirebaseDB:
             write_log("error", e)
             raise UnauthorizedError
 
-    def store_scan_record(self, request_body: Dict[str, List[str]], uid: str) -> None:
+    def store_scan_record(self, uid: str, request_body: Dict[str, List[str]]) -> None:
         try:
             self.root.child("users").child(uid).child("scans").child(
                 str(datetime.now().timestamp()).replace(".", "")
@@ -72,6 +72,15 @@ class FirebaseDB:
     def test_delete_user_data(self, uid: str) -> None:
         try:
             self.root.child("users").child(uid).delete()
+        except Exception as e:
+            write_log("error", e)
+            raise InternalServerError
+
+    def update_scan_record(self, id: str, state: str, uid: str) -> None:
+        try:
+            self.root.child("users").child(uid).child("scans").child(id).child(
+                "state"
+            ).set(state)
         except Exception as e:
             write_log("error", e)
             raise InternalServerError

--- a/api-gateway/database/__init__.py
+++ b/api-gateway/database/__init__.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 from firebase_admin.auth import UserRecord, EmailAlreadyExistsError
 from firebase_admin.db import Reference
 from middleware.error_handling import write_log, UnauthorizedError, InternalServerError
+from datetime import datetime
 
 load_dotenv()
 
@@ -47,13 +48,23 @@ class FirebaseDB:
 
     def store_scan_record(self, request_body: Dict[str, List[str]], uid: str) -> None:
         try:
-            self.root.child("users").child(uid).child("scans").push().set(
+            self.root.child("users").child(uid).child("scans").child(
+                str(datetime.now().timestamp()).replace(".", "")
+            ).set(
                 dict(
                     zones=list(set(request_body.get("zones"))),
                     regions=list(set(request_body.get("regions"))),
                     state="active",
                 )
             )
+        except Exception as e:
+            write_log("error", e)
+            raise InternalServerError
+
+    def get_scan_records(self, uid: str) -> object:
+        try:
+            scans: object = self.root.child("users").child(uid).child("scans").get()
+            return scans
         except Exception as e:
             write_log("error", e)
             raise InternalServerError

--- a/api-gateway/database/__init__.py
+++ b/api-gateway/database/__init__.py
@@ -85,6 +85,13 @@ class FirebaseDB:
             write_log("error", e)
             raise InternalServerError
 
+    def delete_scan_record(self, id: str, uid: str) -> None:
+        try:
+            self.root.child("users").child(uid).child("scans").child(id).delete()
+        except Exception as e:
+            write_log("error", e)
+            raise InternalServerError
+
 
 class FirebaseAuth:
     def __init__(self) -> None:

--- a/api-gateway/middleware/validator.py
+++ b/api-gateway/middleware/validator.py
@@ -1,7 +1,12 @@
 from typing import Dict, Any, Optional, Union
 from flask import request, Response
 import json
-from models import UserSchema, OrganizationEmailSchema, CreateScanSchema
+from models import (
+    UserSchema,
+    OrganizationEmailSchema,
+    CreateScanSchema,
+    UpdateScanSchema,
+)
 from functools import wraps
 from middleware.error_handling import write_log
 
@@ -9,6 +14,7 @@ validator_schemas: Dict[str, Any] = {
     "User": UserSchema,
     "OrganizationEmail": OrganizationEmailSchema,
     "CreateScan": CreateScanSchema,
+    "UpdateScan": UpdateScanSchema,
 }
 
 

--- a/api-gateway/models/__init__.py
+++ b/api-gateway/models/__init__.py
@@ -90,3 +90,15 @@ class CreateScanSchema(Schema):
 
         if not set(regions).issubset(set(regions_list)):
             raise ValidationError("One or more provided GCP regions are invalid")
+
+
+class UpdateScanSchema(Schema):
+    state: String = fields.Str(required=True)
+
+    @validates_schema
+    def check_state(self, post_data: Dict[str, Any], **kwargs) -> None:
+        state: str = post_data.get("state")
+        if state not in ["active", "suspend"]:
+            raise ValidationError(
+                f"Provided state [{state}] is not valid. Acceptable states are ['active','suspend']"
+            )

--- a/api-gateway/services/services.py
+++ b/api-gateway/services/services.py
@@ -109,3 +109,11 @@ class Service:
         except Exception as e:
             write_log("error", e)
             raise InternalServerError
+
+    def get_scans(self, uid) -> Union[ResourceType, Response]:
+        try:
+            data: object = self.firebase_db.get_scan_records(uid)
+            return dict(data=data), 200
+        except Exception as e:
+            write_log("error", e)
+            raise InternalServerError

--- a/api-gateway/services/services.py
+++ b/api-gateway/services/services.py
@@ -124,10 +124,21 @@ class Service:
         self, uid: str, request_body: Dict[str, Any], **kwargs: Dict[str, str]
     ) -> Union[ResourceType, Response]:
         try:
-            state = request_body.get("state", "")
-            id = kwargs.get("id", "")
+            state: str = request_body.get("state", "")
+            id: str = kwargs.get("id", "")
             self.firebase_db.update_scan_record(id, state, uid)
             return dict(message=f"[{id}] state updated successfully"), 200
+        except Exception as e:
+            write_log("error", e)
+            raise InternalServerError
+
+    def delete_scan(
+        self, uid: str, **kwargs: Dict[str, str]
+    ) -> Union[ResourceType, Response]:
+        try:
+            id: str = kwargs.get("id", "")
+            self.firebase_db.delete_scan_record(id, uid)
+            return dict(message=f"scan [{id}] deleted successfully"), 200
         except Exception as e:
             write_log("error", e)
             raise InternalServerError

--- a/api-gateway/services/services.py
+++ b/api-gateway/services/services.py
@@ -102,18 +102,32 @@ class Service:
             write_log("error", e)
             raise NotFoundError
 
-    def create_scan(self, request_body, uid) -> Union[ResourceType, Response]:
+    def create_scan(
+        self, uid: str, request_body: Dict[str, Any]
+    ) -> Union[ResourceType, Response]:
         try:
-            self.firebase_db.store_scan_record(request_body, uid)
+            self.firebase_db.store_scan_record(uid, request_body)
             return dict(message="Scan has successfully recorded"), 200
         except Exception as e:
             write_log("error", e)
             raise InternalServerError
 
-    def get_scans(self, uid) -> Union[ResourceType, Response]:
+    def get_scans(self, uid: str) -> Union[ResourceType, Response]:
         try:
             data: object = self.firebase_db.get_scan_records(uid)
             return dict(data=data), 200
+        except Exception as e:
+            write_log("error", e)
+            raise InternalServerError
+
+    def update_scan(
+        self, uid: str, request_body: Dict[str, Any], **kwargs: Dict[str, str]
+    ) -> Union[ResourceType, Response]:
+        try:
+            state = request_body.get("state", "")
+            id = kwargs.get("id", "")
+            self.firebase_db.update_scan_record(id, state, uid)
+            return dict(message=f"[{id}] state updated successfully"), 200
         except Exception as e:
             write_log("error", e)
             raise InternalServerError

--- a/api-gateway/static/openapi.json
+++ b/api-gateway/static/openapi.json
@@ -242,6 +242,42 @@
       }
     },
     "/scans": {
+      "get": {
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "tags": [
+          "Get Scans Endpoint"
+        ],
+        "description": "Get all the scans for the authenticated user",
+        "operationId": "getScans",
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "Response of the scans",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetScansResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "security": [
           {
@@ -273,6 +309,88 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CreateScanResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/scans/{id}": {
+      "patch": {
+        "tags": [
+          "Update Scans Endpoint"
+        ],
+        "description": "Update the state of a scan by given ID by an authenticated user",
+        "operationId": "updateScan",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "ID of the scan to be updated"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response of updating the state of the scan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateScanResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Delete Scans Endpoint"
+        ],
+        "description": "Delete a scan by given ID by an authenticated user",
+        "operationId": "deleteScan",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "ID of the scan to be deleted"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response of deleting the scan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteScanResponse"
                 }
               }
             }
@@ -429,6 +547,106 @@
         },
         "example": {
           "message": "Scan has successfully recorded"
+        }
+      },
+      "GetScansResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "object",
+                "properties": {
+                  "regions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "state": {
+                    "type": "string"
+                  },
+                  "zones": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "example": {
+          "data": {
+            "1624893385247991": {
+              "regions": [
+                "us-east1-b",
+                "us-east1-c"
+              ],
+              "state": "active",
+              "zones": [
+                ".com",
+                ".lk"
+              ]
+            },
+            "1624893391046098": {
+              "regions": [
+                "us-east1-c",
+                "us-east1-b"
+              ],
+              "state": "active",
+              "zones": [
+                ".lk",
+                ".com"
+              ]
+            },
+            "1624893397158731": {
+              "regions": [
+                "us-east1-c",
+                "us-east1-b"
+              ],
+              "state": "active",
+              "zones": [
+                ".lk",
+                ".com"
+              ]
+            },
+            "1624980505513786": {
+              "regions": [
+                "us-east1-c",
+                "us-east1-b"
+              ],
+              "state": "active",
+              "zones": [
+                ".com",
+                ".org"
+              ]
+            }
+          }
+        }
+      },
+      "UpdateScanResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "message": "[{id}] state updated successfully"
+        }
+      },
+      "DeleteScanResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "message": "scan [{id}] deleted successfully"
         }
       },
       "CheckEmailResponse": {

--- a/api-gateway/static/openapi.json
+++ b/api-gateway/static/openapi.json
@@ -241,7 +241,7 @@
         }
       }
     },
-    "/scan": {
+    "/scans": {
       "post": {
         "security": [
           {

--- a/api-gateway/tests/static/test_get_current_scans.html
+++ b/api-gateway/tests/static/test_get_current_scans.html
@@ -1,0 +1,56 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Get Current Scans</title>
+    <style>
+      table,
+      td,
+      th {
+        border: 1px solid black;
+      }
+    </style>
+  </head>
+  <body onload="myFunction()">
+    <h3>Current Scans</h3>
+
+    <table id="dataTable">
+      <tr>
+        <th>ID</th>
+        <th>State</th>
+        <th>Region</th>
+        <th>Zones</th>
+      </tr>
+    </table>
+
+    <script>
+      async function myFunction() {
+        const token = "";
+        let table = document.getElementById("dataTable");
+        const response = await fetch("http://localhost:5005/scans", {
+          method: "GET",
+          headers: {
+            Authorization: "Bearer " + token,
+          },
+        });
+        const res = await response.json();
+        const data = res?.data;
+        Object.keys(data).forEach((id) => {
+          let row = table.insertRow(-1);
+          let cell1 = row.insertCell(0);
+          let cell2 = row.insertCell(1);
+          let cell3 = row.insertCell(2);
+          let cell4 = row.insertCell(3);
+          cell1.innerHTML = id;
+          cell2.innerHTML = data[id]["state"];
+          cell3.innerHTML = data[id]["regions"].join(" ");
+          cell4.innerHTML = data[id]["zones"].join(" ");
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/api-gateway/tests/static/test_get_gcp_zones.html
+++ b/api-gateway/tests/static/test_get_gcp_zones.html
@@ -24,7 +24,9 @@
           return (document.getElementById("zoneList").innerHTML = "");
         }
         let query = x.value;
-        const response = await fetch("http://localhost:9999/gcp-zones/" + query);
+        const response = await fetch(
+          "http://localhost:9999/gcp-zones/" + query
+        );
         const res = await response.json();
         const zones = res?.data;
         document.getElementById("zoneList").innerHTML = "";

--- a/api-gateway/tests/test_create_scan.py
+++ b/api-gateway/tests/test_create_scan.py
@@ -6,7 +6,7 @@ from werkzeug.test import TestResponse
 from tests.test_firebaser import get_id_token
 
 
-class TestCreateScanController(TestCase):
+class TestScansController(TestCase):
     def setUp(self) -> None:
         self.app: FlaskClient = app.test_client()
         self.uid = "UchQlgJb9ibBoV991fqtQ5ykfHz2"
@@ -25,4 +25,15 @@ class TestCreateScanController(TestCase):
         self.assertIsInstance(result, dict)
         self.assertIsInstance(result.get("message"), str)
         self.assertEqual(result.get("message"), "Scan has successfully recorded")
+        self.assertEqual(code, 200)
+
+    def test_get_scans(self) -> None:
+        response: TestResponse = self.app.get(
+            "/scans",
+            headers=dict(Authorization=f"Bearer {get_id_token(self.uid)}"),
+        )
+        result: Dict[str, Any] = response.json
+        code: int = response.status_code
+        self.assertIsInstance(result, dict)
+        self.assertIsInstance(result.get("data"), dict)
         self.assertEqual(code, 200)

--- a/api-gateway/tests/test_create_scan.py
+++ b/api-gateway/tests/test_create_scan.py
@@ -13,7 +13,7 @@ class TestCreateScanController(TestCase):
 
     def test_create_scan(self) -> None:
         response: TestResponse = self.app.post(
-            "/scan",
+            "/scans",
             json=dict(
                 zones=[".com", ".lk"],
                 regions=["us-east1-b", "us-east1-c"],

--- a/api-gateway/tests/test_firebaser.py
+++ b/api-gateway/tests/test_firebaser.py
@@ -18,7 +18,7 @@ def get_id_token(uid: str):
     firebase_admin.initialize_app(cred, name="TEST_APP")
     custom_token = auth.create_custom_token(uid).decode("utf-8")
     res: Response = requests.post(
-        "https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyCustomToken?key=AIzaSyAvQ_5T0ld46B7nAChU20odyYKRrTI5ois",
+        f"https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyCustomToken?key={getenv('FIREBASE_API_KEY')}",
         data=dict(token=custom_token, returnSecureToken=True),
     )
     return res.json().get("idToken")

--- a/api-gateway/tests/test_update_scan.py
+++ b/api-gateway/tests/test_update_scan.py
@@ -6,34 +6,34 @@ from werkzeug.test import TestResponse
 from tests.test_firebaser import get_id_token
 
 
-class TestScansController(TestCase):
+class TestScanController(TestCase):
     def setUp(self) -> None:
         self.app: FlaskClient = app.test_client()
         self.uid = "UchQlgJb9ibBoV991fqtQ5ykfHz2"
 
-    def test_create_scan(self) -> None:
-        response: TestResponse = self.app.post(
-            "/scans",
-            json=dict(
-                zones=[".com", ".org"],
-                regions=["us-east1-b", "us-east1-c"],
-            ),
+    def test_update_scan(self) -> None:
+        response: TestResponse = self.app.patch(
+            "/scans/1624893376207075",
+            json=dict(state="suspend"),
             headers=dict(Authorization=f"Bearer {get_id_token(self.uid)}"),
         )
         result: Dict[str, Any] = response.json
         code: int = response.status_code
         self.assertIsInstance(result, dict)
         self.assertIsInstance(result.get("message"), str)
-        self.assertEqual(result.get("message"), "Scan has successfully recorded")
+        self.assertEqual(
+            result.get("message"), "[1624893376207075] state updated successfully"
+        )
         self.assertEqual(code, 200)
 
-    def test_get_scans(self) -> None:
-        response: TestResponse = self.app.get(
-            "/scans",
+    def test_delete_scan(self) -> None:
+        response: TestResponse = self.app.delete(
+            "/scans/1624893376207075",
             headers=dict(Authorization=f"Bearer {get_id_token(self.uid)}"),
         )
         result: Dict[str, Any] = response.json
         code: int = response.status_code
         self.assertIsInstance(result, dict)
-        self.assertIsInstance(result.get("data"), dict)
+        self.assertIsInstance(result.get("message"), str)
+        self.assertEqual(result.get("message"), "Scan record has successfully removed")
         self.assertEqual(code, 200)

--- a/api-gateway/tests/test_update_scan.py
+++ b/api-gateway/tests/test_update_scan.py
@@ -35,5 +35,7 @@ class TestScanController(TestCase):
         code: int = response.status_code
         self.assertIsInstance(result, dict)
         self.assertIsInstance(result.get("message"), str)
-        self.assertEqual(result.get("message"), "Scan record has successfully removed")
+        self.assertEqual(
+            result.get("message"), "scan [1624893376207075] deleted successfully"
+        )
         self.assertEqual(code, 200)

--- a/api-gateway/tests/test_update_scan.py
+++ b/api-gateway/tests/test_update_scan.py
@@ -13,7 +13,7 @@ class TestScanController(TestCase):
 
     def test_update_scan(self) -> None:
         response: TestResponse = self.app.patch(
-            "/scans/1624893376207075",
+            "/scans/1624893391046098",
             json=dict(state="suspend"),
             headers=dict(Authorization=f"Bearer {get_id_token(self.uid)}"),
         )
@@ -22,7 +22,7 @@ class TestScanController(TestCase):
         self.assertIsInstance(result, dict)
         self.assertIsInstance(result.get("message"), str)
         self.assertEqual(
-            result.get("message"), "[1624893376207075] state updated successfully"
+            result.get("message"), "[1624893391046098] state updated successfully"
         )
         self.assertEqual(code, 200)
 


### PR DESCRIPTION
This pr closes #6 and closes #7

# In this pr,

- Add route functions for the endpoint GET `/scans`
- Add route functions for the endpoint PATCH `/scans/<id>`
- Add route functions for the endpoint DELETE `/scans/<id>`
- Update Swagger UI documentation for the above endpoints