### PR TITLE
Add Google reCAPTCHA v3 verification to `/register` endpoint

### DIFF
--- a/api-gateway/config/__init__.py
+++ b/api-gateway/config/__init__.py
@@ -20,3 +20,6 @@ class Config:
     MAIL_USERNAME: str = os.environ.get("MAIL_USERNAME")
     MAIL_PASSWORD: str = os.environ.get("MAIL_PASSWORD")
     MAIL_DEFAULT_SENDER: str = os.environ.get("MAIL_DEFAULT_SENDER")
+    GOOGLE_RECAPTCHA_SITE_KEY: str = os.environ.get("GOOGLE_RECAPTCHA_SITE_KEY")
+    GOOGLE_RECAPTCHA_SECRET_KEY: str = os.environ.get("GOOGLE_RECAPTCHA_SECRET_KEY")
+    GOOGLE_RECAPTCHA_SCORE_THRESHOLD: str = 0.5

--- a/api-gateway/controllers/controllers.py
+++ b/api-gateway/controllers/controllers.py
@@ -17,9 +17,9 @@ class RootEndPointController(Resource):
 
 
 class ZonesController(Resource):
-    @cache.cached(timeout=1000)
-    def get(self, query: str) -> ResourceType:
-        return service.get_zone(query)
+    @authenticate
+    def get(self, uid: str, **kwargs: Dict[str, str]) -> ResourceType:
+        return service.get_zone(uid, **kwargs)
 
 
 class RegistrationController(Resource):

--- a/api-gateway/controllers/controllers.py
+++ b/api-gateway/controllers/controllers.py
@@ -2,6 +2,7 @@ from collections import Callable
 from typing import List, Dict, Any
 from config.CustomTypes import ResourceType
 from middleware.auth import authenticate
+from middleware.google_recaptcha import google_recaptcha
 from middleware.validator import validator
 from services import Service
 from flask_restful import Resource
@@ -23,7 +24,9 @@ class ZonesController(Resource):
 
 
 class RegistrationController(Resource):
-    method_decorators: Dict[str, List[Callable]] = dict(post=[validator])
+    method_decorators: Dict[str, List[Callable]] = dict(
+        post=[validator, google_recaptcha]
+    )
     model: str = "User"
 
     def post(self, request_body: Dict[str, Any]) -> ResourceType:

--- a/api-gateway/controllers/controllers.py
+++ b/api-gateway/controllers/controllers.py
@@ -17,9 +17,9 @@ class RootEndPointController(Resource):
 
 
 class ZonesController(Resource):
-    @authenticate
-    def get(self, uid: str, **kwargs: Dict[str, str]) -> ResourceType:
-        return service.get_zone(uid, **kwargs)
+    @cache.cached(timeout=1000)
+    def get(self, query: str) -> ResourceType:
+        return service.get_zone(query)
 
 
 class RegistrationController(Resource):

--- a/api-gateway/database/__init__.py
+++ b/api-gateway/database/__init__.py
@@ -8,6 +8,7 @@ from firebase_admin.auth import UserRecord, EmailAlreadyExistsError
 from firebase_admin.db import Reference
 from middleware.error_handling import write_log, UnauthorizedError, InternalServerError
 from datetime import datetime
+from itertools import chain
 
 load_dotenv()
 
@@ -65,6 +66,18 @@ class FirebaseDB:
         try:
             scans: object = self.root.child("users").child(uid).child("scans").get()
             return scans
+        except Exception as e:
+            write_log("error", e)
+            raise InternalServerError
+
+    def get_scanning_zones(self, uid: str) -> List[str]:
+        try:
+            scans: object = self.get_scan_records(uid)
+            if not scans:
+                return []
+            current_zones_list: List[str] = [scans[id]["zones"] for id in scans]
+            current_zones: List[str] = list(set(chain(*current_zones_list)))
+            return current_zones
         except Exception as e:
             write_log("error", e)
             raise InternalServerError

--- a/api-gateway/database/__init__.py
+++ b/api-gateway/database/__init__.py
@@ -3,25 +3,21 @@ from os.path import abspath, join, dirname, realpath
 from typing import Any, Dict, List, Union, Tuple
 import firebase_admin
 from firebase_admin import credentials, auth, db
-from os import getenv
-from dotenv import load_dotenv
 from firebase_admin.auth import UserRecord, EmailAlreadyExistsError
 from firebase_admin.db import Reference
 from flask import Response
+from config import Config
 from config.CustomTypes import ResourceType
 from middleware.error_handling import write_log, UnauthorizedError, InternalServerError
 from datetime import datetime
 from itertools import chain
 from middleware.validator import send_error
 
-load_dotenv()
 
 cred: Any = credentials.Certificate(
-    abspath(
-        join(dirname(dirname(realpath(__file__))), "config", getenv("FIREBASE_JSON"))
-    )
+    abspath(join(dirname(dirname(realpath(__file__))), "config", Config.FIREBASE_JSON))
 )
-firebase_admin.initialize_app(cred, {"databaseURL": getenv("FIREBASE_DATABASE_URL")})
+firebase_admin.initialize_app(cred, {"databaseURL": Config.FIREBASE_DATABASE_URL})
 
 
 class FirebaseDB:

--- a/api-gateway/database/__init__.py
+++ b/api-gateway/database/__init__.py
@@ -1,14 +1,18 @@
+import itertools
 from os.path import abspath, join, dirname, realpath
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union, Tuple
 import firebase_admin
 from firebase_admin import credentials, auth, db
 from os import getenv
 from dotenv import load_dotenv
 from firebase_admin.auth import UserRecord, EmailAlreadyExistsError
 from firebase_admin.db import Reference
+from flask import Response
+from config.CustomTypes import ResourceType
 from middleware.error_handling import write_log, UnauthorizedError, InternalServerError
 from datetime import datetime
 from itertools import chain
+from middleware.validator import send_error
 
 load_dotenv()
 
@@ -47,17 +51,51 @@ class FirebaseDB:
             write_log("error", e)
             raise UnauthorizedError
 
-    def store_scan_record(self, uid: str, request_body: Dict[str, List[str]]) -> None:
+    def store_scan_record(
+        self, uid: str, request_body: Dict[str, List[str]]
+    ) -> Union[ResourceType, Response]:
         try:
-            self.root.child("users").child(uid).child("scans").child(
-                str(datetime.now().timestamp()).replace(".", "")
-            ).set(
-                dict(
-                    zones=list(set(request_body.get("zones"))),
-                    regions=list(set(request_body.get("regions"))),
-                    state="active",
+            zones: List[str] = list(set(request_body.get("zones")))
+            regions: List[str] = list(set(request_body.get("regions")))
+            input_scanning_combinations: List[Tuple[Any]] = list(
+                itertools.product(zones, regions)
+            )
+            scans: object = self.get_scan_records(uid)
+            if not bool(scans):
+                scans: Dict[str, Dict[str, Any]] = dict()
+            current_zones_list: List[str] = [scans[id]["zones"] for id in scans]
+            current_zones: List[str] = list(set(chain(*current_zones_list)))
+            current_regions_list: List[str] = [scans[id]["regions"] for id in scans]
+            current_regions: List[str] = list(set(chain(*current_regions_list)))
+            current_scanning_combinations: List[Tuple[Any, ...]] = list(
+                itertools.product(current_zones, current_regions)
+            )
+            available_scans: List[Tuple[Any, ...]] = list(
+                set(input_scanning_combinations).difference(
+                    set(current_scanning_combinations)
                 )
             )
+            if len(available_scans) > 0:
+                available_zones, available_regions = zip(*available_scans)
+            else:
+                available_zones, available_regions = list(), list()
+
+            if len(available_zones) > 0 and len(available_regions) > 0:
+                self.root.child("users").child(uid).child("scans").child(
+                    str(datetime.now().timestamp()).replace(".", "")
+                ).set(
+                    dict(
+                        zones=list(set(available_zones)),
+                        regions=list(set(available_regions)),
+                        state="active",
+                    )
+                )
+                return dict(message="Scan has successfully recorded"), 200
+            else:
+                return send_error(
+                    "no new scannable zones, regions to set",
+                    "The zones and regions you set are already scanning",
+                )
         except Exception as e:
             write_log("error", e)
             raise InternalServerError
@@ -66,18 +104,6 @@ class FirebaseDB:
         try:
             scans: object = self.root.child("users").child(uid).child("scans").get()
             return scans
-        except Exception as e:
-            write_log("error", e)
-            raise InternalServerError
-
-    def get_scanning_zones(self, uid: str) -> List[str]:
-        try:
-            scans: object = self.get_scan_records(uid)
-            if not scans:
-                return []
-            current_zones_list: List[str] = [scans[id]["zones"] for id in scans]
-            current_zones: List[str] = list(set(chain(*current_zones_list)))
-            return current_zones
         except Exception as e:
             write_log("error", e)
             raise InternalServerError

--- a/api-gateway/main.py
+++ b/api-gateway/main.py
@@ -1,4 +1,4 @@
 from server import app
 
 if __name__ == "__main__":
-    app.run(host="127.0.0.1", port=9999, debug=True)
+    app.run(host="127.0.0.1", port=9888, debug=True)

--- a/api-gateway/middleware/google_recaptcha.py
+++ b/api-gateway/middleware/google_recaptcha.py
@@ -1,0 +1,45 @@
+from functools import wraps
+from typing import Dict, Optional, Callable, Any, Union
+from config import Config
+from config.CustomTypes import ResourceType
+from middleware.validator import send_error
+from flask import request, Response
+import requests
+
+
+def google_recaptcha(func: Callable[..., ResourceType]):
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Dict[str, str]) -> Union[ResourceType, Response]:
+        request_body: Optional[Any] = request.get_json()
+        g_recaptcha_response: str = request_body.get("g_recaptcha_response")
+
+        if g_recaptcha_response:
+            response: Any = requests.post(
+                "https://www.google.com/recaptcha/api/siteverify",
+                data=dict(
+                    secret=Config.GOOGLE_RECAPTCHA_SECRET_KEY,
+                    response=g_recaptcha_response,
+                    remoteip=request.remote_addr,
+                ),
+            )
+
+            response_dict: Dict[str, Any] = response.json()
+            if (
+                response_dict.get("success")
+                and response_dict.get("score") > Config.GOOGLE_RECAPTCHA_SCORE_THRESHOLD
+            ):
+                return func(*args, **kwargs)
+            else:
+                return send_error(
+                    "reCAPTCHA score is lower",
+                    "Human interaction is required for registration!",
+                    400,
+                )
+        else:
+            return send_error(
+                "No Google reCAPTCHA token provided",
+                "Human interaction is required for registration!",
+                400,
+            )
+
+    return wrapper

--- a/api-gateway/models/__init__.py
+++ b/api-gateway/models/__init__.py
@@ -38,6 +38,7 @@ class UserSchema(Schema):
     profession: String = fields.Str(required=True)
     reason: String = fields.Str(required=True)
     password: String = fields.Str(required=True)
+    g_recaptcha_response: String = fields.Str(required=True)
 
     @validates_schema
     def check_org_email(self, user_data: Dict[str, Any], **kwargs) -> None:

--- a/api-gateway/requirements.txt
+++ b/api-gateway/requirements.txt
@@ -1,4 +1,6 @@
 aniso8601==9.0.1
+blinker==1.4
+Brotli==1.0.9
 CacheControl==0.12.6
 cachetools==4.2.2
 certifi==2021.5.30
@@ -9,7 +11,9 @@ colorama==0.4.4
 firebase-admin==5.0.0
 Flask==2.0.1
 Flask-Caching==1.10.1
+Flask-Compress==1.9.0
 Flask-Cors==3.0.10
+Flask-Mail==0.9.1
 Flask-RESTful==0.3.9
 flask-swagger-ui==3.36.0
 google-api-core==1.29.0
@@ -28,16 +32,20 @@ idna==2.10
 importlib-metadata==4.5.0
 itsdangerous==2.0.1
 Jinja2==3.0.1
+lxml==4.6.3
 MarkupSafe==2.0.1
 marshmallow==3.12.1
 msgpack==1.0.2
+numpy==1.20.3
 packaging==20.9
+pandas==1.2.4
 proto-plus==1.18.1
 protobuf==3.17.2
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.20
 pyparsing==2.4.7
+python-dateutil==2.8.1
 python-dotenv==0.17.1
 pytz==2021.1
 requests==2.25.1

--- a/api-gateway/storer/__init__.py
+++ b/api-gateway/storer/__init__.py
@@ -1,15 +1,14 @@
 from os.path import abspath, join, dirname, realpath
 from typing import Any
 from google.cloud import storage
-from os import getenv
-from dotenv import load_dotenv
 from google.cloud.storage import Bucket
+from config import Config
 
-load_dotenv()
+
 storage_client: Any = storage.Client.from_service_account_json(
-    abspath(join(dirname(dirname(realpath(__file__))), "config", getenv("GCS_JSON")))
+    abspath(join(dirname(dirname(realpath(__file__))), "config", Config.GCS_JSON))
 )
-bucket: Bucket = storage_client.get_bucket(getenv("GCS_BUCKET_NAME"))
+bucket: Bucket = storage_client.get_bucket(Config.GCS_BUCKET_NAME)
 
 
 class Storer:

--- a/api-gateway/tests/static/test_register_user.html
+++ b/api-gateway/tests/static/test_register_user.html
@@ -1,0 +1,64 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta
+            name="viewport"
+            content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
+    <title>Register User</title>
+</head>
+<body>
+<h3>User Registration</h3>
+<br/>
+<br/>
+<form>
+    <label for="full-name">Full Name</label><br/>
+    <input type="text" id="full-name" name="full-name" value=""/><br/>
+    <label for="email">Email</label><br/>
+    <input type="email" id="email" name="email" value=""/><br/><br/>
+    <label for="organization">Organization</label><br/>
+    <input type="text" id="organization" name="organization" value=""/><br/>
+    <label for="profession">Profession</label><br/>
+    <input type="text" id="profession" name="profession" value=""/><br/><br/>
+    <label for="reason">Reason</label><br/>
+    <input type="text" id="reason" name="reason" value=""/><br/><br/>
+    <label for="password">Password</label><br/>
+    <input type="password" id="password" name="password" value=""/><br/><br/>
+    <input type="button" value="Register" onclick="registerUser()"/>
+</form>
+
+<script src="https://www.google.com/recaptcha/api.js?render="></script>
+<script>
+    async function registerUser() {
+        let fullName = document.getElementById("full-name");
+        let email = document.getElementById("email");
+        let organization = document.getElementById("organization");
+        let profession = document.getElementById("profession");
+        let reason = document.getElementById("reason");
+        let password = document.getElementById("password");
+
+        grecaptcha.ready(function () {
+            grecaptcha.execute('', {action: 'register'}).then(async function (token) {
+                await fetch(`http://localhost:9888/register`, {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Accept: "application/json"
+                    },
+                    body: JSON.stringify({
+                        full_name: fullName.value,
+                        email: email.value,
+                        organization: organization.value,
+                        profession: profession.value,
+                        reason: reason.value,
+                        password: password.value,
+                        "g_recaptcha_response": token
+                    }),
+                });
+            });
+        });
+    }
+</script>
+</body>
+</html>

--- a/api-gateway/tests/static/test_update_scans.html
+++ b/api-gateway/tests/static/test_update_scans.html
@@ -1,0 +1,82 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Update Scan State</title>
+    <style>
+      table,
+      td,
+      th {
+        border: 1px solid black;
+      }
+    </style>
+  </head>
+  <body onload="myFunction()">
+    <h3>Current Scans</h3>
+
+    <table id="dataTable">
+      <tr>
+        <th>ID</th>
+        <th>State</th>
+        <th>Region</th>
+        <th>Zones</th>
+      </tr>
+    </table>
+
+    <br />
+    <br />
+    <form>
+      <label for="scan-id">Scan ID:</label><br />
+      <input type="text" id="scan-id" name="scan-id" value="" /><br />
+      <label for="state">State:</label><br />
+      <input type="text" id="state" name="state" value="" /><br /><br />
+      <input type="button" value="Update Scan State" onclick="updateState()" />
+    </form>
+
+    <script>
+      const token = "";
+
+      async function updateState() {
+        let scanID = document.getElementById("scan-id");
+        let state = document.getElementById("state");
+        await fetch(`http://localhost:9999/scans/${scanID.value}`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            Authorization: "Bearer " + token,
+          },
+          body: JSON.stringify({ state: state.value }),
+        });
+        location.reload();
+      }
+
+      async function myFunction() {
+        let table = document.getElementById("dataTable");
+        const response = await fetch("http://localhost:9999/scans", {
+          method: "GET",
+          headers: {
+            Authorization: "Bearer " + token,
+          },
+        });
+        const res = await response.json();
+        const data = res?.data;
+        Object.keys(data).forEach((id) => {
+          let row = table.insertRow(-1);
+          let cell1 = row.insertCell(0);
+          let cell2 = row.insertCell(1);
+          let cell3 = row.insertCell(2);
+          let cell4 = row.insertCell(3);
+          cell1.innerHTML = id;
+          cell2.innerHTML = data[id]["state"];
+          cell3.innerHTML = data[id]["regions"].join(" ");
+          cell4.innerHTML = data[id]["zones"].join(" ");
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/api-gateway/tests/test_create_scan.py
+++ b/api-gateway/tests/test_create_scan.py
@@ -15,7 +15,7 @@ class TestScansController(TestCase):
         response: TestResponse = self.app.post(
             "/scans",
             json=dict(
-                zones=[".com", ".org"],
+                zones=[".com", ".lk"],
                 regions=["us-east1-b", "us-east1-c"],
             ),
             headers=dict(Authorization=f"Bearer {get_id_token(self.uid)}"),

--- a/api-gateway/tests/test_get_zone.py
+++ b/api-gateway/tests/test_get_zone.py
@@ -3,15 +3,19 @@ from unittest import TestCase
 from server import app
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
+from tests.test_firebaser import get_id_token
 
 
 class TestZonesController(TestCase):
     def setUp(self) -> None:
         self.app: FlaskClient = app.test_client()
+        self.uid = "UchQlgJb9ibBoV991fqtQ5ykfHz2"
 
     def test_get_zone(self) -> None:
-        response: TestResponse = self.app.get("/zones/com")
+        response: TestResponse = self.app.get(
+            "/zones/us", headers=dict(Authorization=f"Bearer {get_id_token(self.uid)}")
+        )
         result: Dict[str, Any] = response.json
         self.assertIsInstance(result, dict)
         self.assertIsInstance(result.get("data"), list)
-        self.assertEqual(len(result.get("data")), 11)
+        self.assertEqual(len(result.get("data")), 20)


### PR DESCRIPTION
This pr closes #10 issue.

# In this pr,

1. Add UI test cases for PATCH `/scans/<id>` endpoint
2. Add validation to POST `/zones` endpoint to figure out which zones, regions tuples are required to store as new scan records
3. Add Google reCAPTCHA v3 verification to POST `/register` endpoint